### PR TITLE
Add tests for prime and utility functions

### DIFF
--- a/detect_prime.py
+++ b/detect_prime.py
@@ -1,5 +1,5 @@
-#prim_func(1,2,3,4,5,6) => 2,3,5
-def prim_func(lis):
+# prime_func([1,2,3,4,5,6]) => [2,3,5]
+def prime_func(lis):
   op = []
   for el in lis:
     factor_count = 0
@@ -9,4 +9,4 @@ def prim_func(lis):
     if factor_count == 2:
       op.append(el)
   return op
-print(prim_func([2,3,4,5,6]))
+

--- a/sum_squares.py
+++ b/sum_squares.py
@@ -6,4 +6,4 @@ def sum_even(lis1):
   for i in lis1[1::2]:
     sum+=i
   return sum
-sum_even(lis1)
+

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,24 @@
+import unittest
+from detect_prime import prime_func
+from find_binary import binary
+from sum_squares import sum_even
+
+
+class TestScripts(unittest.TestCase):
+    def test_prime_func_basic(self):
+        self.assertEqual(prime_func([1, 2, 3, 4, 5, 6]), [2, 3, 5])
+        self.assertEqual(prime_func([]), [])
+        self.assertEqual(prime_func([8, 9, 10]), [])
+
+    def test_binary_basic(self):
+        self.assertEqual(binary(5), "101")
+        self.assertEqual(binary(0), "0")
+        self.assertEqual(binary(1), "1")
+
+    def test_sum_even_basic(self):
+        self.assertEqual(sum_even([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), 30)
+        self.assertEqual(sum_even([1]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- rename `prim_func` to `prime_func` and remove script execution
- remove automatic call from `sum_even`
- add test suite covering `prime_func`, `binary` and `sum_even`
- make `tests` a package so `python -m unittest` works

## Testing
- `python -m unittest -v`

------
https://chatgpt.com/codex/tasks/task_e_684489ba8e0c83308029dda303ffa2e9